### PR TITLE
Fix thrift includes logic to only add js imports for directly included thrift files

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "clean-test-output": "git clean -Xdf test-output/",
     "build-test": "babel src -d dist-test --source-maps",
     "build": "babel src/main -d lib --source-maps",
+    "watch": "babel src/main -d lib --source-maps --watch",
     "check": "npm run prettier && npm run lint && npm run test",
     "debug": "node --nolazy --inspect-brk=9229 lib/index.js",
     "download-typedefs": "mkdir -p typedefs && curl -o typedefs/flowResult.js https://raw.githubusercontent.com/facebook/flow/master/tsrc/flowResult.js",

--- a/src/test/collections.spec.js
+++ b/src/test/collections.spec.js
@@ -77,7 +77,7 @@ function go(s : MyStructXXX) {
 `,
     },
     (t: Test, r: FlowResult) => {
-      t.deepEqual(r.errors, []);
+      t.equal(r.errors.length, 0);
       t.end();
     }
   )
@@ -116,7 +116,7 @@ function go(s : MyStructXXX) {
 `,
     },
     (t: Test, r: FlowResult) => {
-      t.deepEqual(r.errors, []);
+      t.equal(r.errors.length, 0);
       t.end();
     }
   )

--- a/src/test/consts.spec.js
+++ b/src/test/consts.spec.js
@@ -72,7 +72,7 @@ function go(s : MyStructXXX): Array<string | number> {
 `,
     },
     (t: Test, r: FlowResult) => {
-      t.deepEqual(r.errors, []);
+      t.equal(r.errors.length, 0);
       t.end();
     }
   )

--- a/src/test/enums.spec.js
+++ b/src/test/enums.spec.js
@@ -68,7 +68,7 @@ const t: EnumTypedefXXX = ok;
 `,
     },
     (t: Test, r: FlowResult) => {
-      t.deepEqual(r.errors, []);
+      t.equal(r.errors.length, 0);
       t.end();
     }
   )

--- a/src/test/imports.spec.js
+++ b/src/test/imports.spec.js
@@ -30,13 +30,21 @@ import type {Test} from 'tape';
 import {flowResultTest} from './util';
 
 // TODO: test relative paths
-
 test(
   'imports in same folder',
   flowResultTest(
     {
       // language=thrift
+      'other.thrift': `
+        typedef i32 Thing 
+      `,
+      // language=thrift
       'shared.thrift': `
+include "./other.thrift"
+
+struct ThingStruct {
+    1: other.Thing thing
+}
 struct OtherStruct {
     1: i32 num
 }
@@ -66,7 +74,7 @@ struct MyStruct {
           `,
     },
     (t: Test, r: FlowResult) => {
-      t.deepEqual(r.errors, []);
+      t.equal(r.errors.length, 0);
       t.end();
     }
   )

--- a/src/test/primitives.spec.js
+++ b/src/test/primitives.spec.js
@@ -67,7 +67,7 @@ function go(s : PrimitivesXXX) {
 `,
     },
     (t: Test, r: FlowResult) => {
-      t.deepEqual(r.errors, []);
+      t.equal(r.errors.length, 0);
       t.end();
     }
   )

--- a/src/test/services.spec.js
+++ b/src/test/services.spec.js
@@ -63,7 +63,7 @@ function ensureVoid(f : any => void) {
 `,
     },
     (t: Test, r: FlowResult) => {
-      t.deepEqual(r.errors, []);
+      t.equal(r.errors.length, 0);
       t.end();
     }
   )

--- a/src/test/typedefs.spec.js
+++ b/src/test/typedefs.spec.js
@@ -74,7 +74,7 @@ function go(s : MyStructXXX) {
           `,
     },
     (t: Test, r: FlowResult) => {
-      t.deepEqual(r.errors, []);
+      t.equal(r.errors.length, 0);
       t.end();
     }
   )

--- a/src/test/unions.spec.js
+++ b/src/test/unions.spec.js
@@ -70,7 +70,7 @@ function go(s : MyStructXXX, u: UnionTypedefXXX, eu: EmptyUnionTypedefXXX) {
 `,
     },
     (t: Test, r: FlowResult) => {
-      t.deepEqual(r.errors, []);
+      t.equal(r.errors.length, 0);
       t.end();
     }
   )


### PR DESCRIPTION
Previously we were adding js imports for all transitive thrift includes.
For example, if a.thrift included b.thrift, and b.thrift included c.thrift, our 
generated js file for a would import the types from both b an c. This updates the
logic to only add imports for direct dependencies, not transitive ones.