### PR TITLE
Update optional properties to be optional properties with nullable values

### DIFF
--- a/src/__tests__/fixtures/optional-struct.thrift
+++ b/src/__tests__/fixtures/optional-struct.thrift
@@ -1,0 +1,3 @@
+struct MyStruct {
+  1: optional string a
+}

--- a/src/__tests__/primitives.test.js
+++ b/src/__tests__/primitives.test.js
@@ -113,12 +113,11 @@ function go(s : Primitives) {
 `,
     },
     r => {
-      expect(r.errors.length).toBe(2);
-      expect(r.errors.length).toBe(2);
+      expect(r.errors.length).toBe(4);
       expect(r.errors[0].level).toBe('error');
       expect(r.errors[1].level).toBe('error');
       expect(r.errors[0].message[0].line).toBe(8);
-      expect(r.errors[1].message[0].line).toBe(9);
+      expect(r.errors[2].message[0].line).toBe(9);
       done();
     }
   );

--- a/src/__tests__/struct.test.js
+++ b/src/__tests__/struct.test.js
@@ -37,7 +37,21 @@ test('structs and have enum properties', () => {
 import * as common from \\"./a/common\\";
 import * as unrelated from \\"./unrelated\\";
 
-export type Foo = {| propA?: $Values<typeof common.EntityTypeA> |};
+export type Foo = {| propA?: ?$Values<typeof common.EntityTypeA> |};
+"
+`);
+});
+
+test('structs with optional properties', () => {
+  const converter = new ThriftFileConverter(
+    `src/__tests__/fixtures/optional-struct.thrift`,
+    false
+  );
+  const jsContent = converter.generateFlowFile();
+  expect(jsContent).toMatchInlineSnapshot(`
+"// @flow
+
+export type MyStruct = {| a?: ?string |};
 "
 `);
 });
@@ -53,7 +67,7 @@ test('unions in typedefs from transitive dependencies are referenced as types', 
 
 import * as fileb from \\"./fileb\\";
 
-export type AStruct = {| prop?: $Values<typeof fileb.ShadowEnum> |};
+export type AStruct = {| prop?: ?$Values<typeof fileb.ShadowEnum> |};
 "
 `);
 });

--- a/src/__tests__/unions.test.js
+++ b/src/__tests__/unions.test.js
@@ -23,10 +23,10 @@
  * SOFTWARE.
  */
 
-import { flowResultTest } from "./util";
-import { ThriftFileConverter } from "../main/convert";
+import {flowResultTest} from './util';
+import {ThriftFileConverter} from '../main/convert';
 
-test("Long module is imported when needed", () => {
+test('Long module is imported when needed', () => {
   const converter = new ThriftFileConverter(
     `src/__tests__/fixtures/union-long-import.thrift`,
     false
@@ -47,11 +47,11 @@ export type RawValue =
 `);
 });
 
-test("unions", done => {
+test('unions', done => {
   flowResultTest(
     {
       // language=thrift
-      "types.thrift": `
+      'types.thrift': `
 typedef MyUnion UnionTypedef
 typedef MyEmptyUnion EmptyUnionTypedef
 
@@ -71,7 +71,7 @@ struct MyStruct {
 }
 `,
       // language=JavaScript
-      "index.js": `
+      'index.js': `
 // @flow
 import type { MyStruct, UnionTypedef, EmptyUnionTypedef } from './types';
 
@@ -84,7 +84,7 @@ function go(s : MyStruct, u: UnionTypedef, eu: EmptyUnionTypedef) {
   const numbers: number[] = [s.f_MyUnion.size || -1];
   return [unions,unions,unionDefs,emptyunionDefs,strings,numbers];
 }
-`
+`,
     },
     r => {
       expect(r.errors.length).toBe(0);

--- a/src/main/convert.js
+++ b/src/main/convert.js
@@ -329,11 +329,12 @@ export class ThriftFileConverter {
     `{|${fields
       .map((field: Field) => {
         const valueType = field.valueType;
+        let optionalPrefix = this.isOptional(field) ? '?' : '';
         let value =
           valueType.type === 'Identifier'
             ? this.getIdentifier(valueType.name, 'type')
             : this.convertType(valueType);
-        return `${field.name}${this.isOptional(field) ? '?' : ''}: ${value};`;
+        return `${field.name}${optionalPrefix}: ${optionalPrefix}${value};`;
       })
       .join('\n')}|}`;
 


### PR DESCRIPTION
This allows more flexible code while maintaining the same level of safety.
For example, both of the following scenarios would be valid assuming `prop` is
optional.

```js
doThing({
  prop: null
}) 

doThing({})
```

Fixes #47