### PR TITLE
Remove ReadOnlyArray logic for enums

### DIFF
--- a/src/__tests__/consts/const-lists.test.js
+++ b/src/__tests__/consts/const-lists.test.js
@@ -52,14 +52,14 @@ export const Direction: $ReadOnly<{|
   RIGHT: \\"RIGHT\\"
 });
 
-export const DIRECTIONS: number[] = [
+export const DIRECTIONS: $Values<typeof Direction>[] = [
   Direction.LEFT,
   Direction.RIGHT,
   Direction.LEFT,
   Direction.RIGHT
 ];
 
-export const DIRECTIONS_LIST: number[] = [
+export const DIRECTIONS_LIST: $Values<typeof Direction>[] = [
   Direction.LEFT,
   Direction.RIGHT,
   Direction.LEFT,

--- a/src/__tests__/consts/const-lists.test.js
+++ b/src/__tests__/consts/const-lists.test.js
@@ -52,14 +52,14 @@ export const Direction: $ReadOnly<{|
   RIGHT: \\"RIGHT\\"
 });
 
-export const DIRECTIONS: $ReadOnlyArray<$Values<typeof Direction>> = [
+export const DIRECTIONS: number[] = [
   Direction.LEFT,
   Direction.RIGHT,
   Direction.LEFT,
   Direction.RIGHT
 ];
 
-export const DIRECTIONS_LIST: $ReadOnlyArray<$Values<typeof Direction>> = [
+export const DIRECTIONS_LIST: number[] = [
   Direction.LEFT,
   Direction.RIGHT,
   Direction.LEFT,

--- a/src/__tests__/consts/consts.test.js
+++ b/src/__tests__/consts/consts.test.js
@@ -77,6 +77,15 @@ export const THINGS: { [$Values<typeof ShieldType>]: string[] } = {
   [ShieldType.U]: [\\"uuuuuuu\\"]
 };
 
+export const ITEMS: $Values<typeof ShieldType>[] = [ShieldType.O, ShieldType.U];
+
+export const MAP_CONST_LIST: {
+  [$Values<typeof ShieldType>]: $Values<typeof ShieldType>[]
+} = {
+  [ShieldType.O]: ITEMS,
+  [ShieldType.U]: []
+};
+
 export const NUMS: { [number]: string } = {
   [0]: \\"aaa\\",
   [1]: \\"bbb\\"

--- a/src/__tests__/fixtures/const-map-literal-type.thrift
+++ b/src/__tests__/fixtures/const-map-literal-type.thrift
@@ -22,6 +22,16 @@ const map<ShieldType, list<string>> THINGS = {
   ShieldType.U: ["uuuuuuu"],
 }
 
+const list<ShieldType> ITEMS = [
+  ShieldType.O,
+  ShieldType.U,
+];
+
+const map<ShieldType, list<ShieldType>> MAP_CONST_LIST = {
+  ShieldType.O: ITEMS,
+  ShieldType.U: [],
+}
+
 const map<i32, string> NUMS = {
   0: "aaa",
   1: "bbb",

--- a/src/main/convert.js
+++ b/src/main/convert.js
@@ -218,30 +218,10 @@ export class ThriftFileConverter {
 
   generateConst = (def: Const) => {
     let value: string | void;
-    let enumType: ?string;
     if (def.value.type === 'ConstList') {
       value = `[${def.value.values
         .map((val: Identifier | Literal) => {
           if (val.type === 'Identifier') {
-            if (val.name.includes('.')) {
-              const {definition} = this.definitionOfIdentifier(
-                val.name,
-                this.thrift.filename
-              );
-              if (definition.type == 'EnumDefinition') {
-                const scope = val.name.split('.')[0];
-                const defAndFilename = this.definitionOfIdentifier(
-                  scope,
-                  this.thrift.filename
-                );
-                if (enumType === undefined && this.isEnum(defAndFilename)) {
-                  enumType = `$ReadOnlyArray<${this.getIdentifier(
-                    scope,
-                    'type'
-                  )}>`;
-                }
-              }
-            }
             return this.getIdentifier(val.name, 'value');
           }
           if (val.type === 'Literal' && typeof val.value === 'string') {
@@ -275,7 +255,7 @@ export class ThriftFileConverter {
         throw new Error(`value is undefined for ${def.id.name}`);
       }
     }
-    const fieldType = enumType || this.convertType(def.fieldType);
+    const fieldType = this.convertType(def.fieldType);
     return `export const ${def.id.name}: ${fieldType} = ${value};`;
   };
 

--- a/src/main/convert.js
+++ b/src/main/convert.js
@@ -218,10 +218,27 @@ export class ThriftFileConverter {
 
   generateConst = (def: Const) => {
     let value: string | void;
+    let enumType: ?string;
     if (def.value.type === 'ConstList') {
       value = `[${def.value.values
         .map((val: Identifier | Literal) => {
           if (val.type === 'Identifier') {
+            if (val.name.includes('.')) {
+              const {definition} = this.definitionOfIdentifier(
+                val.name,
+                this.thrift.filename
+              );
+              if (definition.type == 'EnumDefinition') {
+                const scope = val.name.split('.')[0];
+                const defAndFilename = this.definitionOfIdentifier(
+                  scope,
+                  this.thrift.filename
+                );
+                if (enumType === undefined && this.isEnum(defAndFilename)) {
+                  enumType = `${this.getIdentifier(scope, 'type')}[]`;
+                }
+              }
+            }
             return this.getIdentifier(val.name, 'value');
           }
           if (val.type === 'Literal' && typeof val.value === 'string') {
@@ -255,7 +272,7 @@ export class ThriftFileConverter {
         throw new Error(`value is undefined for ${def.id.name}`);
       }
     }
-    const fieldType = this.convertType(def.fieldType);
+    const fieldType = enumType || this.convertType(def.fieldType);
     return `export const ${def.id.name}: ${fieldType} = ${value};`;
   };
 


### PR DESCRIPTION
While technically it is true that enums should not be modified, in practice this additional type safety is not very important, and it causes issues with other aspects of the code generation. This updates enum types to be regular arrays and adds a test case.