### PR TITLE
Make Map Objects Exact

### DIFF
--- a/src/__tests__/typedefs.test.js
+++ b/src/__tests__/typedefs.test.js
@@ -59,9 +59,9 @@ test('typedefs should reference enum types not value', () => {
 
 import * as base from \\"./base\\";
 
-export type TimeRangeByDayOfWeek = {
+export type TimeRangeByDayOfWeek = {|
   [$Values<typeof base.Weekday>]: base.TimeRange[]
-};
+|};
 "
 `);
 });

--- a/src/main/convert.js
+++ b/src/main/convert.js
@@ -652,7 +652,7 @@ export class ThriftFileConverter {
     if (t.type === 'Map') {
       const keyType = this.convertType(t.keyType);
       const valueType = this.convertType(t.valueType);
-      return `{[${keyType}]: ${valueType}}`;
+      return `{| [${keyType}]: ${valueType} |}`;
     }
     return undefined;
   }


### PR DESCRIPTION
As per discussion with @ganemone, this updates thrift2flow so that Maps are converted to exact object types (rather that inexact). This means spread/union/intersection operations behave as expected, as well as opens the path for stricter type safety with commands like Object.values() and Object.entries().