### PR TITLE
Fixed 119 for exported types with reserved keyword names

### DIFF
--- a/src/__tests__/imports.test.js
+++ b/src/__tests__/imports.test.js
@@ -32,12 +32,14 @@ test('imports in same folder', done => {
     {
       'other.thrift': `
         typedef i32 Thing
+        typedef string Symbol
       `,
       'shared.thrift': `
 include "./other.thrift"
 
 struct ThingStruct {
     1: other.Thing thing
+    1: other.Symbol symbol
 }
 struct OtherStruct {
     1: i32 num

--- a/src/main/identifier.js
+++ b/src/main/identifier.js
@@ -14,5 +14,12 @@ export function id(s: string): string {
   if (reservedTypes.includes(s) || reservedTypes.includes(split[0])) {
     return `_${s}`;
   }
+
+  if (split.length > 1) {
+    const lastItem = split.pop();
+    if (reservedTypes.includes(lastItem)) {
+      s = split.join('.') + `.${id(lastItem)}`;
+    }
+  }
   return s;
 }


### PR DESCRIPTION
If a thrift file exports a type with a reserved keyword, such as "Symbol" then that export will be converted to a reserved variable (_Symbol), however the imports and object usage were not also being changed, so if someone used it from an import as otherfile.Symbol, then it wouldn't be changed to the reserved word form and would fail in flowtype.

See #119. 