### PR TITLE
Added static to reserved key words for flow.

### DIFF
--- a/src/__tests__/imports.test.js
+++ b/src/__tests__/imports.test.js
@@ -80,12 +80,20 @@ test('imports with special type file names', done => {
       'any.thrift': `
         typedef i32 Thing
       `,
+      'static.thrift': `
+      union ThriftDataValue {
+        1: bool unknown
+        2: bool asBool
+      }
+      `,
       'shared.thrift': `
 include "./any.thrift"
+include "./static.thrift"
 struct MyStruct {
     1: any.Thing a
     2: map<string, any.Thing> b
     3: map<any.Thing, string> c
+    4: static.ThriftDataValue d
 }
 typedef any.Thing MyTypedef
 const any.Thing MyConst = 10;

--- a/src/main/identifier.js
+++ b/src/main/identifier.js
@@ -1,6 +1,7 @@
 // @flow
 const reservedTypes = [
   'any',
+  'static',
   'mixed',
   'number',
   'throw',


### PR DESCRIPTION
Issue : https://github.com/uber-web/thrift2flow/issues/88

If foo.thrift imports static.thrift and tries to import all from static.thrift it imports it as 
`import * as static from './static';`

which causes this error
`SyntaxError: unknown: Unexpected reserved word 'static'.`
