### PR TITLE
Remove prettier formatting

### DIFF
--- a/flow-typed/npm/prettier_vx.x.x.js
+++ b/flow-typed/npm/prettier_vx.x.x.js
@@ -1,7 +1,0 @@
-// @flow
-
-declare module 'prettier' {
-  declare module.exports: {
-    format(string, config?: mixed): string,
-  };
-}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thrift2flow",
-  "version": "0.11.5",
+  "version": "0.12.0",
   "description": "Convert Thrift definitions to Flowtype declarations",
   "homepage": "https://github.com/uber-node/thrift2flow",
   "bugs": {
@@ -43,7 +43,6 @@
     "babel-polyfill": "^6.23.0",
     "common-path-prefix": "^1.0.0",
     "mkdirp": "^0.5.1",
-    "prettier": "^1.14.2",
     "source-map-support": "^0.4.15",
     "thriftrw": "^3.11.0",
     "uuid": "^3.3.2",
@@ -68,6 +67,7 @@
     "flow-bin": "^0.94.0",
     "fs-extra": "^4.0.3",
     "jest": "^24.1.0",
+    "prettier": "^1.14.2",
     "tmp": "^0.0.33"
   }
 }

--- a/src/__tests__/__snapshots__/enums.test.js.snap
+++ b/src/__tests__/__snapshots__/enums.test.js.snap
@@ -4,11 +4,11 @@ exports[`enum to JS 1`] = `
 "// @flow
 
 export const MyEnum: $ReadOnly<{|
-  OK: \\"OK\\",
-  ERROR: \\"ERROR\\"
+  'OK': 'OK',
+  'ERROR': 'ERROR',
 |}> = Object.freeze({
-  OK: \\"OK\\",
-  ERROR: \\"ERROR\\"
+  'OK': 'OK',
+  'ERROR': 'ERROR',
 });
 "
 `;
@@ -17,19 +17,19 @@ exports[`enums work with typedefs 1`] = `
 "// @flow
 
 export const MyEnum: $ReadOnly<{|
-  OK: \\"OK\\",
-  ERROR: \\"ERROR\\"
+  'OK': 'OK',
+  'ERROR': 'ERROR',
 |}> = Object.freeze({
-  OK: \\"OK\\",
-  ERROR: \\"ERROR\\"
+  'OK': 'OK',
+  'ERROR': 'ERROR',
 });
 
 export const MyOtherEnum: $ReadOnly<{|
-  OK: \\"OK\\",
-  ERROR: \\"ERROR\\"
+  'OK': 'OK',
+  'ERROR': 'ERROR',
 |}> = Object.freeze({
-  OK: \\"OK\\",
-  ERROR: \\"ERROR\\"
+  'OK': 'OK',
+  'ERROR': 'ERROR',
 });
 "
 `;

--- a/src/__tests__/buffer.test.js
+++ b/src/__tests__/buffer.test.js
@@ -37,11 +37,11 @@ test('See how thriftrw decodes js.type i64', () => {
   expect(thrift.MY_BUFF).toEqual(10);
   const converter = new ThriftFileConverter(fixturePath, false);
   expect(converter.generateFlowFile()).toMatchInlineSnapshot(`
-"// @flow
+    "// @flow
 
-export const MY_BUFF: 10 = 10;
-"
-`);
+    export const MY_BUFF: 10 = 10;
+    "
+  `);
 });
 
 test('Try using the toBufferResult fromBufferResult when parsing a struct with an i64 value', () => {
@@ -56,11 +56,13 @@ test('Try using the toBufferResult fromBufferResult when parsing a struct with a
   expect(Buffer.isBuffer(structAgain.value.myProp)).toBeTruthy();
   const converter = new ThriftFileConverter(fixturePath, false);
   expect(converter.generateFlowFile()).toMatchInlineSnapshot(`
-"// @flow
+    "// @flow
 
-export type MyStruct = {| myProp: number | Buffer |};
-"
-`);
+    export type MyStruct = {|
+      myProp: (number | Buffer),
+    |};
+    "
+  `);
 });
 
 test('Ensure flow uses number not buffer for i64', () => {
@@ -72,11 +74,11 @@ test('Ensure flow uses number not buffer for i64', () => {
   expect(thrift.NULL_ID).toEqual(0);
   const converter = new ThriftFileConverter(fixturePath, false);
   expect(converter.generateFlowFile()).toMatchInlineSnapshot(`
-"// @flow
+    "// @flow
 
-export type MY_ID = number | Buffer;
+    export type MY_ID = (number | Buffer);
 
-export const NULL_ID: MY_ID = 0;
-"
-`);
+    export const NULL_ID: MY_ID = 0;
+    "
+  `);
 });

--- a/src/__tests__/consts/const-lists.test.js
+++ b/src/__tests__/consts/const-lists.test.js
@@ -42,29 +42,29 @@ test('const map values are numbers', () => {
   );
   const jsContent = converter.generateFlowFile();
   expect(jsContent).toMatchInlineSnapshot(`
-"// @flow
+    "// @flow
 
-export const Direction: $ReadOnly<{|
-  LEFT: \\"LEFT\\",
-  RIGHT: \\"RIGHT\\"
-|}> = Object.freeze({
-  LEFT: \\"LEFT\\",
-  RIGHT: \\"RIGHT\\"
-});
+    export const Direction: $ReadOnly<{|
+      'LEFT': 'LEFT',
+      'RIGHT': 'RIGHT',
+    |}> = Object.freeze({
+      'LEFT': 'LEFT',
+      'RIGHT': 'RIGHT',
+    });
 
-export const DIRECTIONS: $Values<typeof Direction>[] = [
-  Direction.LEFT,
-  Direction.RIGHT,
-  Direction.LEFT,
-  Direction.RIGHT
-];
+    export const DIRECTIONS: $Values<typeof Direction>[] = [
+      Direction.LEFT,
+      Direction.RIGHT,
+      Direction.LEFT,
+      Direction.RIGHT,
+    ];
 
-export const DIRECTIONS_LIST: $Values<typeof Direction>[] = [
-  Direction.LEFT,
-  Direction.RIGHT,
-  Direction.LEFT,
-  Direction.RIGHT
-];
-"
-`);
+    export const DIRECTIONS_LIST: $Values<typeof Direction>[] = [
+      Direction.LEFT,
+      Direction.RIGHT,
+      Direction.LEFT,
+      Direction.RIGHT,
+    ];
+    "
+  `);
 });

--- a/src/__tests__/consts/const-map.test.js
+++ b/src/__tests__/consts/const-map.test.js
@@ -38,16 +38,19 @@ test('convert const map witth enums', () => {
   expect(thrift.USER_TYPES.user).toEqual(true);
   const jsContent = converter.generateFlowFile();
   expect(jsContent).toMatchInlineSnapshot(`
-"// @flow
+    "// @flow
 
-export const ADMIN_FOOO: \\"admin\\" = \\"admin\\";
+    export const ADMIN_FOOO: 'admin' = 'admin';
 
-export const USER_BAAAR: \\"user\\" = \\"user\\";
+    export const USER_BAAAR: 'user' = 'user';
 
-export const USER_TYPES: $ReadOnly<{| admin: boolean, user: boolean |}> = {
-  [ADMIN_FOOO]: true,
-  [USER_BAAAR]: true
-};
-"
-`);
+    export const USER_TYPES: $ReadOnly<{|
+      'admin': boolean,
+      'user': boolean,
+    |}> = {
+      [ADMIN_FOOO]: true,
+      [USER_BAAAR]: true,
+    };
+    "
+  `);
 });

--- a/src/__tests__/consts/consts.test.js
+++ b/src/__tests__/consts/consts.test.js
@@ -52,12 +52,11 @@ test('const string literals', () => {
   );
   const jsContent = converter.generateFlowFile();
   expect(jsContent).toMatchInlineSnapshot(`
-"// @flow
+    "// @flow
 
-export const A_STRING_LITERAL: \\"my-string-literal-value\\" =
-  \\"my-string-literal-value\\";
-"
-`);
+    export const A_STRING_LITERAL: 'my-string-literal-value' = 'my-string-literal-value';
+    "
+  `);
 });
 
 test('const map values are numbers', () => {
@@ -67,49 +66,69 @@ test('const map values are numbers', () => {
   );
   const jsContent = converter.generateFlowFile();
   expect(jsContent).toMatchInlineSnapshot(`
-"// @flow
+    "// @flow
 
-export const ShieldType: $ReadOnly<{|
-  O: \\"O\\",
-  U: \\"U\\"
-|}> = Object.freeze({
-  O: \\"O\\",
-  U: \\"U\\"
-});
+    export const ShieldType: $ReadOnly<{|
+      'O': 'O',
+      'U': 'U',
+    |}> = Object.freeze({
+      'O': 'O',
+      'U': 'U',
+    });
 
-export const o: \\"ooooooo\\" = \\"ooooooo\\";
+    export const o: 'ooooooo' = 'ooooooo';
 
-export const PRIORITIES: $ReadOnly<{| O: number, U: number |}> = {
-  [ShieldType.O]: 2,
-  [ShieldType.U]: 10
-};
+    export const PRIORITIES: $ReadOnly<{|
+      'O': number,
+      'U': number,
+    |}> = {
+      [ShieldType.O]: 2,
+      [ShieldType.U]: 10,
+    };
 
-export const LABELS: $ReadOnly<{| O: string, U: string |}> = {
-  [ShieldType.O]: o,
-  [ShieldType.U]: \\"uuuuuuu\\"
-};
+    export const LABELS: $ReadOnly<{|
+      'O': string,
+      'U': string,
+    |}> = {
+      [ShieldType.O]: o,
+      [ShieldType.U]: 'uuuuuuu',
+    };
 
-export const THINGS: $ReadOnly<{| O: string[], U: string[] |}> = {
-  [ShieldType.O]: [o, \\"abcd\\"],
-  [ShieldType.U]: [\\"uuuuuuu\\"]
-};
+    export const THINGS: $ReadOnly<{|
+      'O': string[],
+      'U': string[],
+    |}> = {
+      [ShieldType.O]: [
+        o,
+        \\"abcd\\",
+      ],
+      [ShieldType.U]: [
+        \\"uuuuuuu\\",
+      ],
+    };
 
-export const ITEMS: $Values<typeof ShieldType>[] = [ShieldType.O, ShieldType.U];
+    export const ITEMS: $Values<typeof ShieldType>[] = [
+      ShieldType.O,
+      ShieldType.U,
+    ];
 
-export const MAP_CONST_LIST: $ReadOnly<{|
-  O: $Values<typeof ShieldType>[],
-  U: $Values<typeof ShieldType>[]
-|}> = {
-  [ShieldType.O]: ITEMS,
-  [ShieldType.U]: []
-};
+    export const MAP_CONST_LIST: $ReadOnly<{|
+      'O': $Values<typeof ShieldType>[],
+      'U': $Values<typeof ShieldType>[],
+    |}> = {
+      [ShieldType.O]: ITEMS,
+      [ShieldType.U]: [],
+    };
 
-export const NUMS: $ReadOnly<{| \\"0\\": string, \\"1\\": string |}> = {
-  \\"0\\": \\"aaa\\",
-  \\"1\\": \\"bbb\\"
-};
-"
-`);
+    export const NUMS: $ReadOnly<{|
+      '0': string,
+      '1': string,
+    |}> = {
+      '0': 'aaa',
+      '1': 'bbb',
+    };
+    "
+  `);
 });
 
 test('constant enum values', () => {
@@ -119,23 +138,23 @@ test('constant enum values', () => {
   );
   const jsContent = converter.generateFlowFile();
   expect(jsContent).toMatchInlineSnapshot(`
-"// @flow
+    "// @flow
 
-export const PlaceType: $ReadOnly<{|
-  A: \\"A\\",
-  B: \\"B\\"
-|}> = Object.freeze({
-  A: \\"A\\",
-  B: \\"B\\"
-});
+    export const PlaceType: $ReadOnly<{|
+      'A': 'A',
+      'B': 'B',
+    |}> = Object.freeze({
+      'A': 'A',
+      'B': 'B',
+    });
 
-export const UUID_TO_PLACE_TYPE: $ReadOnly<{|
-  \\"123\\": $Values<typeof PlaceType>,
-  \\"456\\": $Values<typeof PlaceType>
-|}> = {
-  \\"123\\": PlaceType.A,
-  \\"456\\": PlaceType.B
-};
-"
-`);
+    export const UUID_TO_PLACE_TYPE: $ReadOnly<{|
+      '123': $Values<typeof PlaceType>,
+      '456': $Values<typeof PlaceType>,
+    |}> = {
+      '123': PlaceType.A,
+      '456': PlaceType.B,
+    };
+    "
+  `);
 });

--- a/src/__tests__/consts/lists.test.js
+++ b/src/__tests__/consts/lists.test.js
@@ -14,29 +14,41 @@ test('const lists are transformed  correctly', () => {
   const converter = new ThriftFileConverter(fixturePath, false);
   const jsContent = converter.generateFlowFile();
   expect(jsContent).toMatchInlineSnapshot(`
-"// @flow
+    "// @flow
 
-export const AAA: \\"AAA\\" = \\"AAA\\";
+    export const AAA: 'AAA' = 'AAA';
 
-export const BBB: \\"BBB\\" = \\"BBB\\";
+    export const BBB: 'BBB' = 'BBB';
 
-export const CCC: \\"CCC\\" = \\"CCC\\";
+    export const CCC: 'CCC' = 'CCC';
 
-export const DDD: \\"DDD\\" = \\"DDD\\";
+    export const DDD: 'DDD' = 'DDD';
 
-export const EEE: \\"EEE\\" = \\"EEE\\";
+    export const EEE: 'EEE' = 'EEE';
 
-export const FFF: \\"FFF\\" = \\"FFF\\";
+    export const FFF: 'FFF' = 'FFF';
 
-export const BBB_LIST: string[] = [BBB];
+    export const BBB_LIST: string[] = [
+      BBB,
+    ];
 
-export const DDDEEEFFF: string[] = [DDD, EEE, FFF];
+    export const DDDEEEFFF: string[] = [
+      DDD,
+      EEE,
+      FFF,
+    ];
 
-export const DDDEEEFFF_ALIAS = DDDEEEFFF;
+    export const DDDEEEFFF_ALIAS = DDDEEEFFF
 
-export const CCCAAA: string[] = [CCC, AAA];
+    export const CCCAAA: string[] = [
+      CCC,
+      AAA,
+    ];
 
-export const CUSTOM_AND_DL_MODEL_TYPES: string[][] = [DDDEEEFFF_ALIAS, CCCAAA];
-"
-`);
+    export const CUSTOM_AND_DL_MODEL_TYPES: string[][] = [
+      DDDEEEFFF_ALIAS,
+      CCCAAA,
+    ];
+    "
+  `);
 });

--- a/src/__tests__/directives/long.test.js
+++ b/src/__tests__/directives/long.test.js
@@ -41,62 +41,66 @@ test('thriftrw parses long and Long as numbers', () => {
   expect(thrift.MY_STRUCT.negNum3).toEqual(1);
   const converter = new ThriftFileConverter(fixturePath, false);
   expect(converter.generateFlowFile()).toMatchInlineSnapshot(`
-"// @flow
+    "// @flow
 
-import thrift2flow$Long from \\"long\\";
+    import thrift2flow$Long from 'long';
 
-export type MyStruct = {|
-  posNum1?: ?(number | thrift2flow$Long),
-  posNum2?: ?(number | thrift2flow$Long),
-  posNum3?: ?(number | Buffer),
-  negNum1?: ?(number | thrift2flow$Long),
-  negNum2?: ?(number | thrift2flow$Long),
-  negNum3?: ?(number | Buffer)
-|};
+    export type MyStruct = {|
+      posNum1?: ?(number | thrift2flow$Long),
+      posNum2?: ?(number | thrift2flow$Long),
+      posNum3?: ?(number | Buffer),
+      negNum1?: ?(number | thrift2flow$Long),
+      negNum2?: ?(number | thrift2flow$Long),
+      negNum3?: ?(number | Buffer),
+    |};
 
-export const MY_STRUCT: $ReadOnly<MyStruct> = {
-  posNum1: 1,
-  posNum2: 1,
-  posNum3: 1,
-  negNum1: 1,
-  negNum2: 1,
-  negNum3: 1
-};
-"
-`);
+    export const MY_STRUCT: $ReadOnly<MyStruct> = {
+      'posNum1': 1,
+      'posNum2': 1,
+      'posNum3': 1,
+      'negNum1': 1,
+      'negNum2': 1,
+      'negNum3': 1,
+    };
+    "
+  `);
 });
 
 test('The `long` import is included from service definition', () => {
   const fixturePath = 'src/__tests__/fixtures/long-from-service.thrift';
   const converter = new ThriftFileConverter(fixturePath, false);
   expect(converter.generateFlowFile()).toMatchInlineSnapshot(`
-"// @flow
+    "// @flow
 
-import thrift2flow$Long from \\"long\\";
+    import thrift2flow$Long from 'long';
 
-export type Validate = {
-  getStatus: ({| userUUID: string |}) => boolean,
-  getSummary: ({|
-    userUUID: string,
-    startTime: number | thrift2flow$Long,
-    endTime: number | thrift2flow$Long
-  |}) => string
-};
-"
-`);
+    export type Validate = {
+      getStatus: ({|
+        userUUID: string,
+      |}) => boolean,
+      getSummary: ({|
+        userUUID: string,
+        startTime: (number | thrift2flow$Long),
+        endTime: (number | thrift2flow$Long),
+      |}) => string,
+    };
+    "
+  `);
 });
 
 test('The `long` import is included from service definition on return', () => {
   const fixturePath = 'src/__tests__/fixtures/long-from-service-return.thrift';
   const converter = new ThriftFileConverter(fixturePath, false);
   expect(converter.generateFlowFile()).toMatchInlineSnapshot(`
-"// @flow
+    "// @flow
 
-import thrift2flow$Long from \\"long\\";
+    import thrift2flow$Long from 'long';
 
-export type Validate = {
-  getStatus: ({| userUUID: string |}) => number | thrift2flow$Long
-};
-"
-`);
+    export type Validate = {
+      getStatus: ({|
+        userUUID: string,
+      |}) => (number | thrift2flow$Long),
+    };
+    "
+  `);
 });

--- a/src/__tests__/enums.test.js
+++ b/src/__tests__/enums.test.js
@@ -38,39 +38,39 @@ test('thriftrw enums work in map constants', () => {
   expect(thrift.THE_ENUM_PROP.DEFAULT).toEqual('DEFAULT');
   const converter = new ThriftFileConverter(fixturePath, false);
   expect(converter.generateFlowFile()).toMatchInlineSnapshot(`
-"// @flow
+    "// @flow
 
-export const THE_ENUM_PROP: $ReadOnly<{|
-  DEFAULT: \\"DEFAULT\\",
-  LOW: \\"LOW\\",
-  HIGH: \\"HIGH\\"
-|}> = Object.freeze({
-  DEFAULT: \\"DEFAULT\\",
-  LOW: \\"LOW\\",
-  HIGH: \\"HIGH\\"
-});
+    export const THE_ENUM_PROP: $ReadOnly<{|
+      'DEFAULT': 'DEFAULT',
+      'LOW': 'LOW',
+      'HIGH': 'HIGH',
+    |}> = Object.freeze({
+      'DEFAULT': 'DEFAULT',
+      'LOW': 'LOW',
+      'HIGH': 'HIGH',
+    });
 
-export const THE_STRING_MAP: $ReadOnly<{|
-  \\"0\\": string,
-  \\"1\\": string,
-  \\"2\\": string
-|}> = {
-  \\"0\\": \\"Some default string\\",
-  \\"1\\": \\"Some low string\\",
-  \\"2\\": \\"Some high string\\"
-};
+    export const THE_STRING_MAP: $ReadOnly<{|
+      '0': string,
+      '1': string,
+      '2': string,
+    |}> = {
+      '0': 'Some default string',
+      '1': 'Some low string',
+      '2': 'Some high string',
+    };
 
-export const THE_STRING_KEY_MAP: $ReadOnly<{|
-  DEFAULT: string,
-  LOW: string,
-  HIGH: string
-|}> = {
-  [THE_ENUM_PROP.DEFAULT]: \\"some other default\\",
-  [THE_ENUM_PROP.LOW]: \\"some other low\\",
-  [THE_ENUM_PROP.HIGH]: \\"some other high\\"
-};
-"
-`);
+    export const THE_STRING_KEY_MAP: $ReadOnly<{|
+      'DEFAULT': string,
+      'LOW': string,
+      'HIGH': string,
+    |}> = {
+      [THE_ENUM_PROP.DEFAULT]: 'some other default',
+      [THE_ENUM_PROP.LOW]: 'some other low',
+      [THE_ENUM_PROP.HIGH]: 'some other high',
+    };
+    "
+  `);
 });
 
 test('thriftrw enums are strings not numbers', () => {
@@ -106,30 +106,30 @@ test('typedefs of enums can be referenced from structs', () => {
     false
   );
   expect(converter.generateFlowFile()).toMatchInlineSnapshot(`
-"// @flow
+    "// @flow
 
-export const EnumTypedef: $ReadOnly<{|
-  OK: \\"OK\\",
-  ERROR: \\"ERROR\\"
-|}> = Object.freeze({
-  OK: \\"OK\\",
-  ERROR: \\"ERROR\\"
-});
+    export const EnumTypedef: $ReadOnly<{|
+      'OK': 'OK',
+      'ERROR': 'ERROR',
+    |}> = Object.freeze({
+      'OK': 'OK',
+      'ERROR': 'ERROR',
+    });
 
-export const MyEnum: $ReadOnly<{|
-  OK: \\"OK\\",
-  ERROR: \\"ERROR\\"
-|}> = Object.freeze({
-  OK: \\"OK\\",
-  ERROR: \\"ERROR\\"
-});
+    export const MyEnum: $ReadOnly<{|
+      'OK': 'OK',
+      'ERROR': 'ERROR',
+    |}> = Object.freeze({
+      'OK': 'OK',
+      'ERROR': 'ERROR',
+    });
 
-export type MyStruct = {|
-  f_MyEnum: $Values<typeof MyEnum>,
-  f_EnumTypedef: $Values<typeof EnumTypedef>
-|};
-"
-`);
+    export type MyStruct = {|
+      f_MyEnum: $Values<typeof MyEnum>,
+      f_EnumTypedef: $Values<typeof EnumTypedef>,
+    |};
+    "
+  `);
 });
 
 test('enums with typedefs', done => {

--- a/src/__tests__/identifiers/false.test.js
+++ b/src/__tests__/identifiers/false.test.js
@@ -35,13 +35,15 @@ test('thriftrw enums work in map constants', () => {
   expect(thrift.MY_ACCESS.allowed).toEqual(false);
   const converter = new ThriftFileConverter(fixturePath, false);
   expect(converter.generateFlowFile()).toMatchInlineSnapshot(`
-"// @flow
+    "// @flow
 
-export type Access = {| allowed?: ?boolean |};
+    export type Access = {|
+      allowed?: ?boolean,
+    |};
 
-export const MY_ACCESS: $ReadOnly<Access> = {
-  allowed: false
-};
-"
-`);
+    export const MY_ACCESS: $ReadOnly<Access> = {
+      'allowed': false,
+    };
+    "
+  `);
 });

--- a/src/__tests__/services.test.js
+++ b/src/__tests__/services.test.js
@@ -69,13 +69,16 @@ test('Extending a service', () => {
   expect(converter.generateFlowFile()).toMatchInlineSnapshot(`
     "// @flow
 
-    import * as service from \\"./service\\";
+    import * as service from './service';
 
     export type ExtendingService = service.RealService;
 
     export type ExtendingServiceWithMethods = {
-      getNumberTwo: ({| a: string, what: boolean |}) => number,
-      ...service.RealService
+      getNumberTwo: ({|
+        a: string,
+        what: boolean,
+      |}) => number,
+      ...service.RealService,
     };
     "
   `);

--- a/src/__tests__/struct.test.js
+++ b/src/__tests__/struct.test.js
@@ -32,14 +32,16 @@ test('structs and have enum properties', () => {
   );
   const jsContent = converter.generateFlowFile();
   expect(jsContent).toMatchInlineSnapshot(`
-"// @flow
+    "// @flow
 
-import * as common from \\"./a/common\\";
-import * as unrelated from \\"./unrelated\\";
+    import * as common from './a/common';
+    import * as unrelated from './unrelated';
 
-export type Foo = {| propA?: ?$Values<typeof common.EntityTypeA> |};
-"
-`);
+    export type Foo = {|
+      propA?: ?$Values<typeof common.EntityTypeA>,
+    |};
+    "
+  `);
 });
 
 test('structs with optional properties', () => {
@@ -49,11 +51,13 @@ test('structs with optional properties', () => {
   );
   const jsContent = converter.generateFlowFile();
   expect(jsContent).toMatchInlineSnapshot(`
-"// @flow
+    "// @flow
 
-export type MyStruct = {| a?: ?string |};
-"
-`);
+    export type MyStruct = {|
+      a?: ?string,
+    |};
+    "
+  `);
 });
 
 test('unions in typedefs from transitive dependencies are referenced as types', () => {
@@ -63,11 +67,13 @@ test('unions in typedefs from transitive dependencies are referenced as types', 
   );
   const jsContent = converter.generateFlowFile();
   expect(jsContent).toMatchInlineSnapshot(`
-"// @flow
+    "// @flow
 
-import * as fileb from \\"./fileb\\";
+    import * as fileb from './fileb';
 
-export type AStruct = {| prop?: ?$Values<typeof fileb.ShadowEnum> |};
-"
-`);
+    export type AStruct = {|
+      prop?: ?$Values<typeof fileb.ShadowEnum>,
+    |};
+    "
+  `);
 });

--- a/src/__tests__/typedefs.test.js
+++ b/src/__tests__/typedefs.test.js
@@ -40,13 +40,13 @@ test('Long module is imported when needed', () => {
     false
   );
   expect(converter.generateFlowFile()).toMatchInlineSnapshot(`
-"// @flow
+    "// @flow
 
-import thrift2flow$Long from \\"long\\";
+    import thrift2flow$Long from 'long';
 
-export type Long = number | thrift2flow$Long;
-"
-`);
+    export type Long = (number | thrift2flow$Long);
+    "
+  `);
 });
 
 test('typedefs should reference enum types not value', () => {
@@ -55,15 +55,15 @@ test('typedefs should reference enum types not value', () => {
     false
   );
   expect(converter.generateFlowFile()).toMatchInlineSnapshot(`
-"// @flow
+    "// @flow
 
-import * as base from \\"./base\\";
+    import * as base from './base';
 
-export type TimeRangeByDayOfWeek = {|
-  [$Values<typeof base.Weekday>]: base.TimeRange[]
-|};
-"
-`);
+    export type TimeRangeByDayOfWeek = {|
+      [$Values<typeof base.Weekday>]: base.TimeRange[],
+    |};
+    "
+  `);
 });
 test('typedef Date', done => {
   flowResultTest(
@@ -139,11 +139,11 @@ test('typedef reserved type', () => {
   fs.writeFileSync(p, `typedef string Symbol`);
   let output = new ThriftFileConverter(p, false).generateFlowFile();
   expect(output).toMatchInlineSnapshot(`
-"// @flow
+    "// @flow
 
-export type _Symbol = string;
-"
-`);
+    export type _Symbol = string;
+    "
+  `);
 });
 
 test('typedef long in global scope', () => {

--- a/src/__tests__/unions.test.js
+++ b/src/__tests__/unions.test.js
@@ -34,19 +34,31 @@ test('Long module is imported when needed', () => {
     false
   );
   expect(converter.generateFlowFile()).toMatchInlineSnapshot(`
-"// @flow
+    "// @flow
 
-import thrift2flow$Long from \\"long\\";
+    import thrift2flow$Long from 'long';
 
-export type RawValue =
-  | {| type: \\"binaryValue\\", binaryValue: Buffer |}
-  | {| type: \\"boolValue\\", boolValue: boolean |}
-  | {| type: \\"doubleValue\\", doubleValue: number |}
-  | {| type: \\"int32Value\\", int32Value: number |}
-  | {| type: \\"int64Value\\", int64Value: number | thrift2flow$Long |}
-  | {| type: \\"stringValue\\", stringValue: string |};
-"
-`);
+    export type RawValue = {|
+      type: \\"binaryValue\\",
+      binaryValue: Buffer,
+    |} | {|
+      type: \\"boolValue\\",
+      boolValue: boolean,
+    |} | {|
+      type: \\"doubleValue\\",
+      doubleValue: number,
+    |} | {|
+      type: \\"int32Value\\",
+      int32Value: number,
+    |} | {|
+      type: \\"int64Value\\",
+      int64Value: (number | thrift2flow$Long),
+    |} | {|
+      type: \\"stringValue\\",
+      stringValue: string,
+    |};
+    "
+  `);
 });
 
 test('unions', done => {

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -8,7 +8,6 @@ type OptionsType = {|
   withSource?: boolean,
   commonPath: string,
   outputDir?: string,
-  skipFormat?: boolean,
 |};
 
 type Parsed = {|
@@ -40,7 +39,7 @@ export default function convert(
       relativeThriftPath,
       `${path.basename(thriftPath, '.thrift')}.js`
     );
-    allOutput[jsFilename] = converter.generateFlowFile(options.skipFormat);
+    allOutput[jsFilename] = converter.generateFlowFile();
   }
   return allOutput;
 }
@@ -68,7 +67,7 @@ export function convertParsed(thriftParsed: Parsed, options: OptionsType) {
       relativeThriftPath,
       `${path.basename(thriftPath, '.thrift')}.js`
     );
-    allOutput[jsFilename] = converter.generateFlowFile(options.skipFormat);
+    allOutput[jsFilename] = converter.generateFlowFile();
   }
   return allOutput;
 }


### PR DESCRIPTION
Remove dependency on prettier by ensuring the generated code output conforms to following style guide producing readable code:
* 2 space indentation
* prefer multi-line for objects and arrays
* trailing commas
* semicolons after each statement
* single quotes (same applies to quotes around object properties where necessary)
* empty line at end of file

Users can run formatter of their choice on generated files separately.